### PR TITLE
[issues/18] Alternative, external require.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An unopinionated model layer / ORM for full-stack Javascript Applications (web, 
         - `create([{data}])`
         - `read([{queries}])`
         - `update([{queries}], [{data}])`
-        - `delete([{queries}], [{data}])`
+        - `destroy([{queries}], [{data}])`
     - Proposed
 2. Model: Query Methods 
     - Standard
@@ -42,8 +42,8 @@ An unopinionated model layer / ORM for full-stack Javascript Applications (web, 
         - `read([{queries}])` -> returns array of instances (empty array returns all instances)
         - `update({query}, {data})` -> updates one instance
         - `update([{queries}], [{data}])` -> updates many instances (empty query array updates all instances)
-        - `delete({queries}, {data})` -> deletes one instance
-        - `delete([{queries}], [{data}])` -> deletes many instances (empty query array updates all instances)
+        - `destroy({queries}, {data})` -> destroys one instance
+        - `destroy([{queries}], [{data}])` -> destroys many instances (empty query array updates all instances)
     - Proposed
         - `first()` -> returns first instance of model
         - `last()` -> returns last instance of model
@@ -55,8 +55,8 @@ An unopinionated model layer / ORM for full-stack Javascript Applications (web, 
         - `afterRead()`
         - `beforeUpdate()`
         - `afterUpdate()`
-        - `beforeDelete()`
-        - `afterDelete()`
+        - `beforeDestroy()`
+        - `afterDestroy()`
     - Proposed
         - `beforeSave()`
         - `afterSave()`

--- a/examples/models/User.js
+++ b/examples/models/User.js
@@ -1,24 +1,22 @@
 try {
     Artisan = require('../../src/lib/Artisan')
 } catch (error) {
-    console.error(error.toString())
+    console.info(error.toString())
 }
+
+
 
 class User extends Artisan {
 
     constructor(attrs) {
-        super({
-            adapters: {
-                client: 'HTTP',
-                server: 'NOOP'
-            },
-            schema: {
-                username: Artisan.types.String,
-                email: Artisan.types.String
-            }
-        })
+        super(attrs)
+    }
 
-        Object.assign(this, attrs)
+    static schema() {
+        return {
+            username: Artisan.types.String,
+            email: Artisan.types.String
+        }
     }
 
     beforeCreate() {
@@ -28,6 +26,7 @@ class User extends Artisan {
     }
 
 }
+
 
 
 if (Artisan.environment() === 'SERVER') {

--- a/examples/models/User.js
+++ b/examples/models/User.js
@@ -21,12 +21,15 @@ class User extends Artisan {
 
     beforeCreate() {
         if (!this.email.match(/@{1}/g)) {
-            throw new Error('Please enter valid email address')
+            throw new Error(User.messages.invalidEmail)
         }
     }
 
 }
 
+User.messages = {
+    invalidEmail: 'Please enter a valid email address.'
+}
 
 
 if (Artisan.environment() === 'SERVER') {

--- a/examples/servers/server.js
+++ b/examples/servers/server.js
@@ -25,7 +25,7 @@ app.get('/User', async (req, res, next) => {
     res.body = await User.update(req.query, req.body)
     res.send()
 }).delete('/User', async (req, res, next) => {
-    res.body = await User.delete(req.query)
+    res.body = await User.destroy(req.query)
     res.send()
 })
 

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/Hiveminde/Artisan/issues"
   },
-  "homepage": "https://github.com/Hiveminde/Artisan#readme"
+  "homepage": "https://github.com/Hiveminde/Artisan#readme",
+  "dependencies": {
+    "express": "^4.15.4"
+  }
 }

--- a/src/lib/Artisan.js
+++ b/src/lib/Artisan.js
@@ -1,5 +1,9 @@
 class Artisan {
 
+    constructor(attrs) {
+        Object.assign(this, attrs)
+    }
+
     static get types() {
         return {
             String: String,
@@ -19,14 +23,12 @@ class Artisan {
         )
     }
 
-
-
-    constructor(config) {
-        if (!this.constructor.adapter) {
-            let adapter = require(`./adapters/${config.adapters[Artisan.environment().toLowerCase()]}`)
-            this.constructor.adapter = new adapter({
-                klass: this.constructor.name
-            })
+    static async config(options) {
+        if (!this.adapter) {
+            this.adapter = await (new options.adapter({
+                klass: this.constructor.name,
+                schema: this.schema()
+            }))
         }
     }
 

--- a/src/lib/Artisan.js
+++ b/src/lib/Artisan.js
@@ -143,36 +143,36 @@ class Artisan {
 
 
 
-    async delete() {
-        if (this.beforeDelete) {
-            await this.beforeDelete()
+    async destroy() {
+        if (this.beforeDestroy) {
+            await this.beforeDestroy()
         }
 
-        let instances = await this.constructor.delete([this])
+        let instances = await this.constructor.destroy([this])
 
-        if (this.afterDelete) {
-            await this.afterDelete()
+        if (this.afterDestroy) {
+            await this.afterDestroy()
         }
 
         Object.assign(this, instances[0])
     }
 
-    static async delete(queryData) {
+    static async destroy(queryData) {
         let instances = queryData.map((data) => data.constructor === this ? data : new this(data))
 
         // Static before hook
-        if (this.beforeDelete) {
-            await this.beforeDelete(instances)
+        if (this.beforeDestroy) {
+            await this.beforeDestroy(instances)
         }
 
         // Make adapter call
-        let outputData = await this.adapter.delete(instances)
+        let outputData = await this.adapter.destroy(instances)
 
         instances = outputData.map((data) => new this(data))
 
         // Static after hook
-        if (this.afterDelete) {
-            await this.afterDelete(instances)
+        if (this.afterDestroy) {
+            await this.afterDestroy(instances)
         }
 
         return instances

--- a/src/lib/Artisan.js
+++ b/src/lib/Artisan.js
@@ -26,7 +26,7 @@ class Artisan {
     static async config(options) {
         if (!this.adapter) {
             this.adapter = await (new options.adapter({
-                klass: this.constructor.name,
+                klass: this.name,
                 schema: this.schema()
             }))
         }

--- a/src/lib/adapters/HTTP.js
+++ b/src/lib/adapters/HTTP.js
@@ -31,7 +31,7 @@ class HTTP {
         })).json()
     }
 
-    async delete(queryArray) {
+    async destroy(queryArray) {
         return await (await fetch(this.baseRoute, {
             method: 'DELETE',
             data: queryArray

--- a/src/lib/adapters/Mongo.js
+++ b/src/lib/adapters/Mongo.js
@@ -24,8 +24,8 @@ class Mongo {
         return await this.collection.update(queryArray, dataArray)
     }
 
-    async delete(queryArray) {
-        return await this.collection.delete(queryArray)
+    async destroy(queryArray) {
+        return await this.collection.destroy(queryArray)
     }
 
 }

--- a/src/lib/adapters/NOOP.js
+++ b/src/lib/adapters/NOOP.js
@@ -16,7 +16,7 @@ class NOOP {
         return await queryArray.map((q, i) => Object.assign(q, dataArray[i]))
     }
 
-    async delete(queryArray) {
+    async destroy(queryArray) {
         return await queryArray
     }
 

--- a/src/lib/adapters/Postgres.js
+++ b/src/lib/adapters/Postgres.js
@@ -20,8 +20,8 @@ class Postgres {
         return await this.table.update(queryArray, dataArray)
     }
 
-    async delete(queryArray) {
-        return await this.table.delete(queryArray)
+    async destroy(queryArray) {
+        return await this.table.destroy(queryArray)
     }
 
 }

--- a/src/lib/adapters/Redis.js
+++ b/src/lib/adapters/Redis.js
@@ -20,7 +20,7 @@ class Redis {
         return await this.collection.put(queryArray, dataArray)
     }
 
-    async delete(queryArray) {
+    async destroy(queryArray) {
         return await this.collection.del(queryArray)
     }
 

--- a/src/lib/adapters/Socket.js
+++ b/src/lib/adapters/Socket.js
@@ -20,7 +20,7 @@ class Socket {
         return await this.sockets.put(queryArray, dataArray)
     }
 
-    async delete(queryArray) {
+    async destroy(queryArray) {
         return await this.sockets.del(queryArray)
     }
 

--- a/src/lib/adapters/scaffold
+++ b/src/lib/adapters/scaffold
@@ -20,8 +20,8 @@ class {{scaffold.name}} {
         return await this.{{scaffold.protocol}}.{{scaffold.crud.update}}(queryArray, dataArray)
     }
 
-    async delete(queryArray) {
-        return await this.{{scaffold.protocol}}.{{scaffold.crud.delete}}(queryArray)
+    async destroy(queryArray) {
+        return await this.{{scaffold.protocol}}.{{scaffold.crud.destroy}}(queryArray)
     }
 
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,7 +1,11 @@
-const User = require('../examples/models/User');
-
-
 (async () => {
+
+    const User = require('../examples/models/User')
+    await User.config({
+        adapter: require('../src/lib/adapters/NOOP')
+    })
+
+
 
     console.log('<----- BEGIN TESTS ----->')
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -52,11 +52,11 @@ const User = require('../examples/models/User');
         let users;
 
         joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
-        await joe.delete()
-        console.log('<User>.delete --result-->', joe.username === 'twincharged')
+        await joe.destroy()
+        console.log('<User>.destroy --result-->', joe.username === 'twincharged')
 
-        users = await User.delete([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
-        console.log('User.delete --result-->', users[0].username === 'twincharged')
+        users = await User.destroy([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
+        console.log('User.destroy --result-->', users[0].username === 'twincharged')
     })()
 
     console.log('<----- END TESTS ----->')

--- a/tests/index.js
+++ b/tests/index.js
@@ -10,57 +10,56 @@
     console.log('<----- BEGIN TESTS ----->')
 
     await (async () => {
-        let joe;
-        let users;
-
-        joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
+        let joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
         await joe.create()
         console.log('<User>.create --result-->', joe.username === 'twincharged')
 
-        users = await User.create([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
+        let users = await User.create([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
         console.log('User.create --result-->', users[0].username === 'twincharged')
     })()
 
 
 
     await (async () => {
-        let joe;
-        let users;
-
-        joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
+        let joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
         await joe.read()
         console.log('<User>.read --result-->', joe.username === 'twincharged')
 
-        users = await User.read([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
+        let users = await User.read([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
         console.log('User.read --result-->', users[0].username === 'twincharged')
     })()
 
 
 
     await (async () => {
-        let joe;
-        let users;
-
-        joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
+        let joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
         await joe.update({ username: 'joe' })
         console.log('<User>.update --result-->', joe.username === 'joe')
 
-        users = await User.update([{ username: 'twincharged', email: 'joe@hiveminde.com' }], [{ username: 'joe' }])
+        let users = await User.update([{ username: 'twincharged', email: 'joe@hiveminde.com' }], [{ username: 'joe' }])
         console.log('User.update --result-->', users[0].username === 'joe')
     })()
 
 
 
     await (async () => {
-        let joe;
-        let users;
-
-        joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
+        let joe = new User({ username: 'twincharged', email: 'joe@hiveminde.com' })
         await joe.destroy()
         console.log('<User>.destroy --result-->', joe.username === 'twincharged')
 
-        users = await User.destroy([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
+        let users = await User.destroy([{ username: 'twincharged', email: 'joe@hiveminde.com' }])
         console.log('User.destroy --result-->', users[0].username === 'twincharged')
+    })()
+
+
+
+    await (async () => {
+        let joe = new User({ username: 'twincharged', email: 'an invalid email' })
+        try {
+            await joe.create()
+        } catch (error) {
+            console.log('<User>.beforeCreate --result-->', error.message === User.messages.invalidEmail)
+        }
     })()
 
     console.log('<----- END TESTS ----->')


### PR DESCRIPTION
@kwonjoseph @jwagstaff We're having difficulties requiring modules on the fly due to environment issues. We would likely have to use a build tool to do this. What do you guys think of this alternative? Feeding the domain-specific adapter into the model within the domain. It is at least more modular and configurable, but less magical.

On line 5 of the tests index file, you can see I'm handing the model it's adapter, rather than artisan trying to infer which adapter to require.